### PR TITLE
Fixing breaking references

### DIFF
--- a/browser_calls_flask/views.py
+++ b/browser_calls_flask/views.py
@@ -53,7 +53,7 @@ def get_token():
         capability.allow_client_incoming('customer')
 
     # Generate the capability token
-    token = capability.generate()
+    token = capability.to_jwt().decode('utf-8')
 
     return jsonify({'token': token})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-Bootstrap==3.3.5.7
 
 # External libraries
 SQLAlchemy==1.0.11
-twilio==6.9.0
+twilio==6.24.1
 phonenumbers==7.2.7
 
 # Testing


### PR DESCRIPTION
This is a fix for issues https://github.com/TwilioDevEd/browser-calls-flask/issues/9 and https://github.com/TwilioDevEd/browser-calls-flask/issues/10. The updated Twilio lib reference addresses another issue where lib v6.9.0 was generating (now) invalid XML