### PR TITLE
Fix: dependency problem and token's TypeError

### DIFF
--- a/browser_calls_flask/views.py
+++ b/browser_calls_flask/views.py
@@ -53,7 +53,7 @@ def get_token():
         capability.allow_client_incoming('customer')
 
     # Generate the capability token
-    token = str(capability.to_jwt(), 'utf-8')
+    token = capability.to_jwt().decode('utf-8')
 
     return jsonify({'token': token})
 

--- a/browser_calls_flask/views.py
+++ b/browser_calls_flask/views.py
@@ -53,7 +53,7 @@ def get_token():
         capability.allow_client_incoming('customer')
 
     # Generate the capability token
-    token = capability.to_jwt()
+    token = str(capability.to_jwt(), 'utf-8')
 
     return jsonify({'token': token})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,13 @@ Flask-WTF==0.12
 Flask-Bootstrap==3.3.5.7
 
 # External libraries
-SQLAlchemy==1.0.11
+SQLAlchemy==1.1.0
 twilio==6.24.1
-phonenumbers==7.2.7
+phonenumbers==8.12.1
+Werkzeug==0.16.1
 
 # Testing
 unittest2==1.1.0
 coverage==4.0.3
 mock==2.0.0
+

--- a/tests/views_tests.py
+++ b/tests/views_tests.py
@@ -57,7 +57,7 @@ class TwilioTokenTests(BaseTest):
     def test_get_token_for_customer_by_default(self):
         # Given
         mock_capability = MagicMock()
-        mock_capability.to_jwt.return_value = 'abc123'
+        mock_capability.to_jwt.return_value = b'abc123'
 
         # When
         with patch('browser_calls_flask.views.ClientCapabilityToken', return_value=mock_capability) as mock:
@@ -74,7 +74,7 @@ class TwilioTokenTests(BaseTest):
     def test_get_token_for_agent_if_referrer_is_dashboard(self):
         # Given
         mock_capability = MagicMock()
-        mock_capability.to_jwt.return_value = 'abc123'
+        mock_capability.to_jwt.return_value = b'abc123'
 
         # When
         with patch('browser_calls_flask.views.ClientCapabilityToken', return_value=mock_capability) as mock:


### PR DESCRIPTION
## Fix dependency problem
- Correct problem below caused by `phonenumber`, `SQLAlchemy` and `Werkzeug`'s version. 
<img width="1136" alt="Screen Shot 2020-04-22 at 9 19 43 AM" src="https://user-images.githubusercontent.com/16266103/80008907-2f71ff80-847d-11ea-9a88-883ae3ae56a2.png">
<img width="1136" alt="Screen Shot 2020-04-22 at 9 21 41 AM" src="https://user-images.githubusercontent.com/16266103/80008938-3993fe00-847d-11ea-8f2f-e7df09543335.png">
<img width="1136" alt="Screen Shot 2020-04-22 at 9 22 24 AM" src="https://user-images.githubusercontent.com/16266103/80008958-4153a280-847d-11ea-903f-44a3624f5755.png">

## Fix python3 decode process
- Correct token's byte to string decode process that removed by #12  
<img width="1136" alt="Screen Shot 2020-04-22 at 9 27 45 AM" src="https://user-images.githubusercontent.com/16266103/80009737-5250e380-847e-11ea-8403-aebcb55f0edd.png">
<img width="1136" alt="Screen Shot 2020-04-22 at 9 49 50 AM" src="https://user-images.githubusercontent.com/16266103/80010004-a360d780-847e-11ea-9fa2-88d285b9f10b.png">
